### PR TITLE
Reimplement dev ModDiscovererMixin in more lightweight way

### DIFF
--- a/src/main/java/com/falsepattern/gasstation/mixins/mixin/dev/ModDiscovererMixin.java
+++ b/src/main/java/com/falsepattern/gasstation/mixins/mixin/dev/ModDiscovererMixin.java
@@ -4,18 +4,12 @@ import com.falsepattern.gasstation.mixins.IModDiscovererMixin;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
-import cpw.mods.fml.common.FMLLog;
-import cpw.mods.fml.common.ModClassLoader;
-import cpw.mods.fml.common.discovery.ContainerType;
 import cpw.mods.fml.common.discovery.ModCandidate;
 import cpw.mods.fml.common.discovery.ModDiscoverer;
 
-import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 @Mixin(value = ModDiscoverer.class,
@@ -28,21 +22,10 @@ public abstract class ModDiscovererMixin implements IModDiscovererMixin {
         return candidates;
     }
 
-    @Inject(method = "findClasspathMods",
-            at = @At(value = "INVOKE",
-                     target = "Lcpw/mods/fml/common/FMLLog;finer(Ljava/lang/String;[Ljava/lang/Object;)V"),
-            locals = LocalCapture.CAPTURE_FAILHARD,
+    @ModifyVariable(method = "findClasspathMods",
+            at = @At("STORE"),
             require = 1)
-    private void smartCheck(ModClassLoader modClassLoader, CallbackInfo ci, List<String> knownLibraries, File[] minecraftSources, int i) {
-        FMLLog.fine("Found a minecraft related file at %s, examining for mod candidates", minecraftSources[i].getAbsolutePath());
-        candidates.add(new ModCandidate(minecraftSources[i], minecraftSources[i], ContainerType.JAR, i == 0, true));
-    }
-
-    @Redirect(method = "findClasspathMods",
-              at = @At(value = "INVOKE",
-                       target = "Lcpw/mods/fml/common/FMLLog;finer(Ljava/lang/String;[Ljava/lang/Object;)V"),
-              require = 1)
-    private void noLog(String format, Object[] data) {
-
+    private List<String> noKnownLibraries(List<String> original) {
+        return Arrays.asList();
     }
 }


### PR DESCRIPTION
CoreTweaks has a patch that redirects `knownLibraries.contains()` in `ModDiscoverer#findClasspathMods` to [a method does a much better job at filtering out libraries](https://github.com/makamys/CoreTweaks/blob/c78b7dd9ba385da68ea57466ff3c11b42afe7393/src/main/java/makamys/coretweaks/asm/ModDiscovererTransformer.java#L87-L144). This typically reduces startup time by 1-2 seconds. Only, it's incompatible with the way GasStation's ModDiscovererMixin is implemented.

This PR reimplements it in a more compatible (and imo clean) way. Functionally it still does the same thing.